### PR TITLE
Update rubocop linter namespaces

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -26,10 +26,10 @@ Style/SymbolArray:
 Style/ParenthesesAroundCondition:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 Metrics/BlockLength:


### PR DESCRIPTION
It appears that in newer versions of rubocop, some of the linters have
moved out of the Style namespace and into the Layout namespace. This
change updates the default rubocop config template to reflect the
current namespace for those linters.