### PR TITLE
Include axe-matchers

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -8,6 +8,7 @@ end
 gem 'pg'
 
 gem_group :development, :test do
+  gem 'axe-matchers'
   gem 'bullet'
   gem 'bundler-audit'
   gem 'capybara'
@@ -115,7 +116,8 @@ copy_file "templates/circle.yml", "circle.yml"
 
 # Capybara
 insert_into_file "spec/rails_helper.rb", after: "# Add additional requires below this line. Rails is not loaded until this point!\n" do
-  "require \"capybara/rails\""
+  "require \"capybara/rails\"\n"\
+    "require \"axe/rspec\"\n"
 end
 
 append_to_file "spec/rails_helper.rb" do


### PR DESCRIPTION
This adds the axe-matchers gem to the default gemfile, which provides
easy acceptance test matchers for accessing the accessibility of
different pages in your application.

Closes #8 