### PR TITLE
Add options to chrome headless

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -129,7 +129,13 @@ append_to_file "spec/rails_helper.rb" do
     "end\n\n"\
     "Capybara.register_driver :headless_chrome do |app|\n"\
     "  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(\n"\
-    "    chromeOptions: { args: %w[headless disable-gpu] }\n"\
+    "    chromeOptions: { args: [\n"\
+    "      \"headless\",\n"\
+    "      \"disable-gpu\",\n"\
+    "      \"no-sandbox\",\n"\
+    "      \"disable-extensions\",\n"\
+    "      \"start-maximized\"\n"\
+    "    ] }\n"\
     "  )\n\n"\
     "  Capybara::Selenium::Driver.new app,\n"\
     "    browser: :chrome,\n"\


### PR DESCRIPTION
This incorporates additional parameters to chrome headless to not run in
sandbox, not have extensions, and start maximized.

Relevant spec_helper section after this change:
```ruby
  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: [
       "headless",
       "disable-gpu",
       "no-sandbox",
       "disable-extensions",
       "--start-maximized"
     ] }
  )
```