### PR TITLE
Use FactoryGirl parent strategy

### DIFF
--- a/templates/spec/support/factory_girl.rb
+++ b/templates/spec/support/factory_girl.rb
@@ -1,3 +1,5 @@
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 end
+
+FactoryGirl.use_parent_strategy = true


### PR DESCRIPTION
This change modifies FactoryGirl's configuration to inherit the strategy
to construct objects from the parent object for associations. Prior to
this change, and the FactoryGirl default, is to `create` all associated
records from the factory, regardless of the strategy of the parent
object.

This previous default resulted in records being persisted to the
database when one wouldn't expect them to be.