### PR TITLE
Update to FactoryBot

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -82,7 +82,7 @@ gem_group :development, :test do
   gem 'capybara'
   gem 'database_cleaner'
   gem 'dotenv-rails'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'gnar-style', require: false
   gem 'pronto'
   gem 'pronto-brakeman', require: false
@@ -130,8 +130,8 @@ gsub_file "spec/rails_helper.rb",
   "# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }",
   "Dir[Rails.root.join(\"spec/support/**/*.rb\")].each { |f| require f }"
 
-# FactoryGirl
-copy_file "templates/spec/support/factory_girl.rb", "spec/support/factory_girl.rb"
+# FactoryBot
+copy_file "templates/spec/support/factory_bot.rb", "spec/support/factory_bot.rb"
 
 # Shoulda Matchers
 append_to_file "spec/rails_helper.rb" do

--- a/templates/spec/support/factory_bot.rb
+++ b/templates/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end
+
+FactoryBot.use_parent_strategy = true

--- a/templates/spec/support/factory_girl.rb
+++ b/templates/spec/support/factory_girl.rb
@@ -1,5 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end
-
-FactoryGirl.use_parent_strategy = true


### PR DESCRIPTION
This commit:
  - Renames all instances and references to `FactoryGirl` to reference
`FactoryBot`

Why?
  - thoughtbot has renamed the gem and `FactoryGirl` will be deprecated.

https://robots.thoughtbot.com/factory_bot