### PR TITLE
Update gnarbot token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ bin/yarn test
 ```
 
 * Generate a Personal Access Token from the gnarbot github account.
-  - Settings > Personal access tokens > Generate new token.
+  - Settings > Developer settings > Personal access tokens > Generate new token.
   - Use the repo name for the token description.
   - Provide the repo scope.
   - Generate token.


### PR DESCRIPTION
This updates the readme to include the new location of the setting to
get to in order to generate a Personal Access Token to use when setting
up gnarbot on a new project.