### PR TITLE
Support Circle 2.0

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -175,7 +175,8 @@ prepend_to_file "spec/spec_helper.rb" do
 end
 
 # Circle CI
-copy_file "templates/circle.yml", "circle.yml"
+copy_file "templates/.circleci/config.yml", ".circleci/config.yml"
+gsub_file ".circleci/config.yml", "__application_name__", "#{app_name}"
 
 # Capybara
 insert_into_file "spec/rails_helper.rb", after: "# Add additional requires below this line. Rails is not loaded until this point!\n" do

--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -1,0 +1,66 @@
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.4.2-stretch-node-browsers
+        environment:
+          RAILS_ENV: test
+      - image: circleci/postgres:9.6.5
+    steps:
+      - checkout
+
+      # Restore bundle cache
+      - restore_cache:
+          key: __application_name__-{{ checksum "Gemfile.lock" }}
+
+      # cmake is required by Rugged, a dependency of Pronto
+      - run:
+          name: Install cmake
+          command: sudo apt-get -y -qq update && sudo apt-get -y -qq install cmake
+
+      # Bundle install dependencies
+      - run:
+          name: Install dependencies
+          command: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - save_cache:
+          key: __application_name__-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      # Database setup
+      - run:
+          name: Create database
+          command: bundle exec rake db:create
+      - run:
+          name: Load database schema
+          command: bundle exec rake db:schema:load
+
+      # Tests
+      - run:
+          name: RSpec
+          command: bundle exec rspec
+
+      # Security analysis
+      - run:
+          name: Bundler Audit
+          command: bundle exec bundle-audit update && bundle exec bundle-audit check
+      - run:
+          name: Brakeman
+          command: ./script/brakeman
+
+      # Pronto
+      - run:
+          name: Pronto
+          command: ./script/ci_pronto
+
+      # Save Brakeman
+      - store_artifacts:
+          path: tmp/brakeman.html
+          destination: security/brakeman.html
+
+      # Save Coverage Analysis
+      - store_artifacts:
+          path: coverage
+          destination: coverage

--- a/templates/circle.yml
+++ b/templates/circle.yml
@@ -1,5 +1,0 @@
-test:
-  post:
-    - bundle exec bundle-audit update && bundle exec bundle-audit check
-    - ./script/brakeman
-    - ./script/ci_pronto


### PR DESCRIPTION
This modifies the template to create an application that will use Circle
CI 2.0 as the CI runner.

This does *not* include any configuration for front-end JS-specific tests.
This will likely need to be modified for any React-specific test setup.

Closes #17 