### PR TITLE
Add lol_dba

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -83,6 +83,7 @@ gem_group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'gnar-style', require: false
+  gem 'lol_dba'
   gem 'pronto'
   gem 'pronto-brakeman', require: false
   gem 'pronto-rubocop', require: false


### PR DESCRIPTION
This adds in the lol_dba gem to the development and test groups to be
used to identify database columns that could benefit from an index.

Closes #20 