### PR TITLE
Specify ruby version in Gemfile

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -110,6 +110,11 @@ gsub_file ".env.test", "__application_name__", "#{app_name}"
 # Remove sqlite gem, if present
 gsub_file "Gemfile", /.*sqlite.*\n/, ""
 
+# Add ruby version to Gemfile
+insert_into_file "Gemfile", after: "source 'https://rubygems.org'" do
+  "\nruby \"2.4.2\""
+end
+
 # Use scss
 run "mv app/assets/stylesheets/application.css app/assets/stylesheets/application.scss"
 


### PR DESCRIPTION
This annotation is required for interfacing with Heroku.

Closes #22 

Gemfile snippet after creating a rails app with the template:
```
source 'https://rubygems.org'
ruby "2.4.2"

git_source(:github) do |repo_name|
  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
  "https://github.com/#{repo_name}.git"
end
```