### PR TITLE
Limit logging in test environment

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -149,6 +149,15 @@ insert_into_file "spec/rails_helper.rb", after: "RSpec.configure do |config|" do
   "\n  if Bullet.enable?\n    config.before(:each) do\n      Bullet.start_request\n    end\n\n    config.after(:each) do\n      Bullet.perform_out_of_channel_notifications if Bullet.notification?\n      Bullet.end_request\n    end\n  end\n"
 end
 
+# Limit Test Logging
+insert_into_file "config/environments/test.rb", after: "Rails.application.configure do" do
+  "\n"\
+    "  unless ENV[\"RAILS_ENABLE_TEST_LOG\"]\n"\
+    "    config.logger = Logger.new(nil)\n"\
+    "    config.log_level = :fatal\n"\
+    "  end\n"
+end
+
 # Rubocop
 copy_file "templates/.rubocop.yml", ".rubocop.yml"
 


### PR DESCRIPTION
This sets the rails logger in test to point to nothing, and raises the
logging level to fatal so that only the highest severity even attempts
to log.

There is an ENV VAR that can be set to override this, if the default
logger should be used in a particular instance. This should decrease
the run time of the test suite for the resulting applications.

Closes #21 