### PR TITLE
Lock pg gem version

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -74,7 +74,7 @@ def modify_npm_scripts
   end
 end
 
-gem 'pg'
+gem 'pg', '~> 0.18'
 
 gem_group :development, :test do
   gem 'axe-matchers'


### PR DESCRIPTION
This updates the gemfile to lock pg to under the 1.0 release of the pg
gem, which rails does not support. This result matches what you would
get if you weren't using this template and executed `rails new APP_NAME
--database=postgresql`.