### PR TITLE
Indicate that `brew` is homebrew/OS X dependent

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew "cmake"
+brew "pkg-config"
+brew "chromedriver"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ $ rails new <APP_NAME> -m path/to/gnarly.rb --skip-test-unit --database=postgres
 
 A`.railsrc` is provided. If you'd like to symlink it to your home directory, it'll run `rails new` with the options to run with postgres and not including test-unit. This `.railsrc` can be personalized to include the `--template=path/to/gnarly.rb` option depending on where you locally store this repo if you'd like to use this template every time.
 
-Error while installing pronto? Try installing cmake
+Error while installing pronto? Try installing [cmake](https://cmake.org/). You can do this on OS X with [homebrew](https://brew.sh/) by running:
+
 ```sh
-brew install cmake
+brew bundle
 ```
 
 # Usage with React


### PR DESCRIPTION
Also: Add a Brewfile: https://github.com/Homebrew/homebrew-bundle

There’s only one dependency that we know of right now, so the Brewfile addition’s kind of a meh since it doesn’t really simplify any onboarding at the moment.