### PR TITLE
Closes #1 - Adds OK Computer as default healthcheck endpoint

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -85,6 +85,7 @@ gem_group :development, :test do
   gem 'factory_bot_rails'
   gem 'gnar-style', require: false
   gem 'lol_dba'
+  gem 'okcomputer'
   gem 'pronto'
   gem 'pronto-brakeman', require: false
   gem 'pronto-rubocop', require: false


### PR DESCRIPTION
We use this on several projects. It is light weight and compatible with pretty much any heartbeat monitor. 