### PR TITLE
CLI command to create new rails app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     gnarails (0.1.0)
       rails
       rspec-rails
+      thor
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # Gnarails
 
-This repo contains a rails template, and all necessary associated files, to provide a fully-loaded Gnar Rails app. Clone this repo locally to use.
+This repo contains a rails template, and all necessary associated files, to provide a fully-loaded Gnar Rails app.
 
 ## Usage
+
+This template relies on pronto, which needs [cmake](https://cmake.org/) installed.
+
+### Using the CLI
+
+```sh
+$ gem install gnarails
+$ gnarails new <APP_NAME>
+```
+
+### Using the template
+
+If you want to reference the template directly and don't want to use the
+gnarails CLI command, you may clone the project (or reference the template from
+its HTTP location on github):
+
 ```sh
 $ git clone https://github.com/TheGnarCo/gnarails.git
 $ cd where/app/will/go
@@ -11,13 +27,16 @@ $ rails new <APP_NAME> -m path/to/gnarly.rb --skip-test-unit --database=postgres
 
 A`.railsrc` is provided. If you'd like to symlink it to your home directory, it'll run `rails new` with the options to run with postgres and not including test-unit. This `.railsrc` can be personalized to include the `--template=path/to/gnarly.rb` option depending on where you locally store this repo if you'd like to use this template every time.
 
-Error while installing pronto? Try installing [cmake](https://cmake.org/). You can do this on OS X with [homebrew](https://brew.sh/) by running:
+## Usage with React
+
+### Using the CLI
 
 ```sh
-brew bundle
+$ gem install gnarails
+$ gnarails new <APP_NAME> --webpack=react
 ```
 
-## Usage with React
+### Using the template
 
 ```sh
 $ git clone https://github.com/TheGnarCo/gnarails.git

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rails new rails-test-app -m gnarly.rb --skip-test-unit --database=postgresql
+bundle exec exe/gnarails new rails-test-app
 
 mkdir rails-test-app/app/views/job_postings
 mkdir rails-test-app/db/migrate

--- a/exe/gnarails
+++ b/exe/gnarails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require "gnarails"
+Gnarails::Cli::Application.start(ARGV)

--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails"
   spec.add_dependency "rspec-rails"
+  spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "gnar-style"

--- a/lib/gnarails.rb
+++ b/lib/gnarails.rb
@@ -1,4 +1,8 @@
+require "gnarails/cli/application"
 require "gnarails/version"
 
 module Gnarails
+  def self.template_file
+    File.join(File.dirname(__FILE__), "..", "gnarly.rb")
+  end
 end

--- a/lib/gnarails/cli/application.rb
+++ b/lib/gnarails/cli/application.rb
@@ -1,0 +1,27 @@
+require "thor"
+
+module Gnarails
+  module Cli
+    class Application < Thor
+      include Thor::Actions
+
+      desc "new <name> <rails-options>", "generate a gnarly rails app"
+      long_desc <<-LONGDESC
+        `gnarails new NAME` will create a new rails application called NAME,
+        pre-built with the same helpful default configuration you can expect from
+        any rails project built by The Gnar Company.
+
+        By default, we pass arguments to `rails new` that skip test unit
+        generation and use postgres instead of sqlite as the default database.
+
+        You should also be able to pass any other arguments you would expect to
+        be able to when generating a new rails app.
+      LONGDESC
+      def new(name, rails_options = nil)
+        default_options = "--skip-test-unit --database=postgresql"
+
+        system "rails new #{name} -m #{Gnarails.template_file} #{default_options} #{rails_options}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This provides a CLI command to generate a new rails application using
Gnar defaults: `gnarails new app-name`. The integration test has been
updated to use this CLI command for testing purposes.

### Local Integration Test Run

```
gnarails|cli-new ⇒ rake
/Users/kevin/.rubies/ruby-2.4.2/bin/ruby -I/Users/kevin/.gem/ruby/2.4.2/gems/rspec-core-3.7.0/lib:/Users/kevin/.gem/ruby/2.4.2/gems/rspec-support-3.7.0/lib /Users/kevin/.gem/ruby/2.4.2/gems/rspec-core-3.7.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 33998
./Users/kevin/dev/gnar/gnarails/rails-test-app/db/schema.rb doesn't exist yet. Run `rails db:migrate` to create it, then try again. If you do not intend to use a database, you should instead alter /Users/kevin/dev/gnar/gnarails/rails-test-app/config/application.rb to limit the frameworks that will be loaded.
.

Finished in 34.25 seconds (files took 0.1272 seconds to load)
2 examples, 0 failures

Randomized with seed 33998
```

Closes #4 