### PR TITLE
Run integration spec in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  build:
+  unit_test:
     docker:
       - image: circleci/ruby:2.4.2-stretch-node-browsers
         environment:
@@ -34,3 +34,132 @@ jobs:
       - run:
           name: RSpec
           command: bundle exec rspec
+
+  build-rails:
+    docker:
+      - image: ruby:2.4.2
+
+    steps:
+      - checkout
+
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+          - gnarails-build-rails-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - gnarails-build-rails-
+
+      # cmake is required by Rugged, a dependency of Pronto
+      - run:
+          name: Install cmake
+          command: apt-get -y -qq update && apt-get -y -qq install cmake
+
+      # Bundle install dependencies
+      - run:
+          name: Install Dependencies
+          command: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - save_cache:
+          paths:
+            - vendor/bundle
+          key: gnarails-build-rails-{{ checksum "Gemfile.lock" }}
+
+      # Generate test app
+      - run:
+          name: Generate Test App
+          command: sh ./bin/generate-test-app.sh && mkdir rails-app && cp -r ~/project/rails-test-app ~/project/rails-app/
+
+      # Save to shared workspace
+      - persist_to_workspace:
+          root: rails-app
+          paths:
+            - rails-test-app
+
+  test-rails-app:
+    docker:
+      - image: circleci/ruby:2.4.2-stretch-node-browsers
+        environment:
+          RAILS_ENV: test
+          PG_HOST: localhost
+          PG_USER: ubuntu
+          DATABASE_URL: "postgres://ubuntu@localhost:5432/rails-test-app-test"
+      - image: circleci/postgres:9.6.5
+        environment:
+          POSTGRES_USER: ubuntu
+          POSTGRES_DB: rails-test-app-test
+
+    steps:
+      - attach_workspace:
+          at: /tmp/rails-test-app
+
+      # Pull rails app from shared workspace
+      - run:
+          name: Copy Test App
+          command: cp -r /tmp/rails-test-app/rails-test-app/* ~/project
+
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+          - gnarails-test-rails-app-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - gnarails-test-rails-app-
+
+      # cmake is required by Rugged, a dependency of Pronto
+      - run:
+          name: Install cmake
+          command: sudo apt-get -y -qq update && sudo apt-get -y -qq install cmake
+
+      # Bundle install dependencies
+      - run:
+          name: install dependencies
+          command: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - save_cache:
+          paths:
+            - vendor/bundle
+          key: gnarails-test-rails-app-{{ checksum "Gemfile.lock" }}
+
+      # Database setup
+      - run:
+          name: Create database
+          command: bundle exec rake db:create && bundle exec rake db:migrate
+
+      # Tests
+      - run:
+          name: RSpec
+          command: bundle exec rspec
+
+     # Security analysis
+      - run:
+          name: Bundler Audit
+          command: bundle exec bundle-audit update && bundle exec bundle-audit check
+      - run:
+          name: Brakeman
+          command: ./script/brakeman
+
+      # Pronto
+      - run:
+          name: Pronto
+          command: ./script/ci_pronto
+
+      # Save Brakeman
+      - store_artifacts:
+          path: tmp/brakeman.html
+          destination: security/brakeman.html
+
+      # Save Coverage Analysis
+      - store_artifacts:
+          path: coverage
+          destination: coverage
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - unit_test
+      - build-rails
+      - test-rails-app:
+          requires:
+            - build-rails

--- a/bin/generate-test-app.sh
+++ b/bin/generate-test-app.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+bundle exec exe/gnarails new rails-test-app
+
+mkdir rails-test-app/app/views/job_postings
+mkdir rails-test-app/db/migrate
+mkdir rails-test-app/spec/factories
+mkdir rails-test-app/spec/models
+mkdir rails-test-app/spec/system
+
+cp test-app/app/controllers/job_postings_controller.rb rails-test-app/app/controllers/job_postings_controller.rb
+cp test-app/app/models/job_posting.rb rails-test-app/app/models/job_posting.rb
+cp test-app/app/views/job_postings/index.html.erb rails-test-app/app/views/job_postings/index.html.erb
+yes | cp test-app/app/views/layouts/application.html.erb rails-test-app/app/views/layouts/application.html.erb
+yes | cp test-app/config/routes.rb rails-test-app/config/routes.rb
+cp test-app/db/migrate/20170918002433_create_job_postings.rb rails-test-app/db/migrate/20170918002433_create_job_postings.rb
+cp test-app/spec/factories/job_postings.rb rails-test-app/spec/factories/job_postings.rb
+cp test-app/spec/models/job_posting_spec.rb rails-test-app/spec/models/job_posting_spec.rb
+cp test-app/spec/system/viewing_all_job_postings_spec.rb rails-test-app/spec/system/viewing_all_job_postings_spec.rb

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -1,21 +1,4 @@
-#!/bin/bash
-bundle exec exe/gnarails new rails-test-app
-
-mkdir rails-test-app/app/views/job_postings
-mkdir rails-test-app/db/migrate
-mkdir rails-test-app/spec/factories
-mkdir rails-test-app/spec/models
-mkdir rails-test-app/spec/system
-
-cp test-app/app/controllers/job_postings_controller.rb rails-test-app/app/controllers/job_postings_controller.rb
-cp test-app/app/models/job_posting.rb rails-test-app/app/models/job_posting.rb
-cp test-app/app/views/job_postings/index.html.erb rails-test-app/app/views/job_postings/index.html.erb
-yes | cp test-app/app/views/layouts/application.html.erb rails-test-app/app/views/layouts/application.html.erb
-yes | cp test-app/config/routes.rb rails-test-app/config/routes.rb
-cp test-app/db/migrate/20170918002433_create_job_postings.rb rails-test-app/db/migrate/20170918002433_create_job_postings.rb
-cp test-app/spec/factories/job_postings.rb rails-test-app/spec/factories/job_postings.rb
-cp test-app/spec/models/job_posting_spec.rb rails-test-app/spec/models/job_posting_spec.rb
-cp test-app/spec/system/viewing_all_job_postings_spec.rb rails-test-app/spec/system/viewing_all_job_postings_spec.rb
+sh ./bin/generate-test-app.sh
 
 cd rails-test-app
 bundle


### PR DESCRIPTION
This updates the circle configuration so that the integration spec from
the sample application may be run, differently from the local setup.

This involves creating a workflow, which is multiple CI jobs put
together, to achieve the same result.
* The first job will run the unit specs for the gnarails project.
* The second job pulls a non-circle ruby image to generate a rails app
using gnarails. This is necessary because it appears the circle ruby
image includes some work that vendors gems in some way that running
`gnarails new` doesn't allow you to access the gems from the rails
session, just from gnarails itself. The result of that rails app is
stored in a workspace, which allows you to share files across jobs in a
workflow.
* The final job grabs the rails app from the shared workspace, runs the
specs, and other configuration items (coverage analysis, security
analysis, etc) that is in the Circle config you get from gnarails to
ensure that creating a new rails app from gnarails will work as
expected.

Closes #75 