### PR TITLE
Avoid suggesting installing chromedriver via NPM

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -15,13 +15,12 @@ $ open http://localhost:3000
 
 ### Testing Dependency:
 
-To run acceptance tests `chromedriver` is required.
+To run acceptance tests chromedriver is required.
 
-Install via homebrew or npm respectively:
+If using macOS and homebrew, you can install chromedriver with the following
+command:
 ```sh
 $ brew install chromedriver
-
-$ npm install chromedriver
 ```
 
 To run the full test suite:


### PR DESCRIPTION
Rather than providing multiple suggestions for installing the
chromedriver package (and potentially finding ourselves in a position to
exhaustively list all ways to install it for various systems, which is
not the point of the README information), this suggests one method using
a tool that most people inside the organization use themselves.