### PR TITLE
Remove existing README

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -229,6 +229,7 @@ else
 end
 
 # README
+remove_file "README.md"
 copy_file "templates/README.md", "README.md"
 gsub_file "README.md", "__application_name__", "#{app_name}"
 


### PR DESCRIPTION
This deletes the existing README prior to adding in the new one,
preventing a situation where creating a new rails app requires human
intervention to answer if the README should be overwritten.