### PR TITLE
Disallow creating webpack app in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ A`.railsrc` is provided. If you'd like to symlink it to your home directory, it'
 
 ## Usage with React
 
-### Using the CLI
-
-```sh
-$ gem install gnarails
-$ gnarails new <APP_NAME> --webpack=react
-```
-
 ### Using the template
 
 ```sh

--- a/lib/gnarails/cli/application.rb
+++ b/lib/gnarails/cli/application.rb
@@ -18,9 +18,36 @@ module Gnarails
         be able to when generating a new rails app.
       LONGDESC
       def new(name, rails_options = nil)
+        disallow_webpack(name, rails_options) if rails_options&.include?("--webpack")
+
         default_options = "--skip-test-unit --database=postgresql"
 
-        system "rails new #{name} -m #{Gnarails.template_file} #{default_options} #{rails_options}"
+        Kernel.system "rails new #{name} -m #{Gnarails.template_file} #{default_options} #{rails_options}"
+      end
+
+      no_tasks do
+        def disallow_webpack(app_name, rails_options)
+          puts webpack_error(app_name, rails_options)
+          exit(1)
+        end
+
+        def webpack_error(app_name, rails_options)
+          <<~ERROR
+            ⚠️  Gnarails cannot create your new rails app. ⚠️
+            ================================================
+            Unfortunately, there's currently an issue installing webpacker using the gnarails CLI tool to create a new rails application.
+
+            ⚡️  Workaround ⚡️
+            ================
+            You can still create a gnarly rails app using the template directly:
+
+            rails new #{app_name} -m https://raw.githubusercontent.com/TheGnarCo/gnarails/master/gnarly.rb --skip-test-unit --database=postgresql #{rails_options}
+
+            🛠  Help Wanted 🛠
+            =================
+            We'd love your help to resolve this issue. We welcome any assistance or insight you may have on this here: https://github.com/TheGnarCo/gnarails/issues/90.
+          ERROR
+        end
       end
     end
   end

--- a/spec/gnarails/cli/application_spec.rb
+++ b/spec/gnarails/cli/application_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "gnarails/cli/application"
+
+module Gnarails
+  module Cli
+    RSpec.describe Application do
+      describe ".new" do
+        subject(:application) { Gnarails::Cli::Application.new }
+
+        it "creates a new rails application" do
+          allow(Kernel).to receive(:system)
+
+          application.new("name", "--option")
+
+          options = "--skip-test-unit --database=postgresql --option"
+          expect(Kernel).to have_received(:system)
+            .with("rails new name -m #{Gnarails.template_file} #{options}")
+        end
+
+        context "trying to use webpacker" do
+          it "does not allow the command to complete" do
+            expect { capture(:stdout) { application.new("name", "--webpack") } }
+              .to raise_error SystemExit
+          end
+        end
+      end
+
+      def capture(stream)
+        begin
+          stream = stream.to_s
+          eval("$#{stream} = StringIO.new")
+          yield
+          result = eval("$#{stream}").string
+        ensure
+          eval("$#{stream} = #{stream.upcase}")
+        end
+
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
Until the CLI can handle installing webpacker as part of creating a new
rails app, the command should fail to execute if the option to use
webpack is provided to it.