### PR TITLE
Support rails generator options

### DIFF
--- a/lib/gnarails/cli/application.rb
+++ b/lib/gnarails/cli/application.rb
@@ -5,7 +5,155 @@ module Gnarails
     class Application < Thor
       include Thor::Actions
 
-      desc "new <name> <rails-options>", "generate a gnarly rails app"
+      add_runtime_options!
+
+      WEBPACKS = %w[react vue angular elm stimulus].freeze
+
+      method_option :ruby,
+        type: :string,
+        aliases: "-r",
+        default: Thor::Util.ruby_command,
+        desc: "Path to the Ruby binary of your choice", banner: "PATH"
+
+      method_option :skip_namespace,
+        type: :boolean,
+        default: false,
+        desc: "Skip namespace (affects only isolated applications)"
+
+      method_option :skip_yarn,
+        type: :boolean,
+        default: false,
+        desc: "Don't use Yarn for managing JavaScript dependencies"
+
+      method_option :skip_gemfile,
+        type: :boolean,
+        default: false,
+        desc: "Don't create a Gemfile"
+
+      method_option :skip_git,
+        type: :boolean,
+        aliases: "-G",
+        default: false,
+        desc: "Skip .gitignore file"
+
+      method_option :skip_keeps,
+        type: :boolean,
+        default: false,
+        desc: "Skip source control .keep files"
+
+      method_option :skip_action_mailer,
+        type: :boolean,
+        aliases: "-M",
+        default: false,
+        desc: "Skip Action Mailer files"
+
+      method_option :skip_active_record,
+        type: :boolean,
+        aliases: "-O",
+        default: false,
+        desc: "Skip Active Record files"
+
+      method_option :skip_active_storage,
+        type: :boolean,
+        default: false,
+        desc: "Skip Active Storage files"
+
+      method_option :skip_puma,
+        type: :boolean,
+        aliases: "-P",
+        default: false,
+        desc: "Skip Puma related files"
+
+      method_option :skip_action_cable,
+        type: :boolean,
+        aliases: "-C",
+        default: false,
+        desc: "Skip Action Cable files"
+
+      method_option :skip_sprockets,
+        type: :boolean,
+        aliases: "-S",
+        default: false,
+        desc: "Skip Sprockets files"
+
+      method_option :skip_spring,
+        type: :boolean,
+        default: false,
+        desc: "Don't install Spring application preloader"
+
+      method_option :skip_listen,
+        type: :boolean,
+        default: false,
+        desc: "Don't generate configuration that depends on the listen gem"
+
+      method_option :skip_coffee,
+        type: :boolean,
+        default: false,
+        desc: "Don't use CoffeeScript"
+
+      method_option :skip_javascript,
+        type: :boolean,
+        aliases: "-J",
+        default: false,
+        desc: "Skip JavaScript files"
+
+      method_option :skip_turbolinks,
+        type: :boolean,
+        default: false,
+        desc: "Skip turbolinks gem"
+
+      method_option :skip_test,
+        type: :boolean,
+        aliases: "-T",
+        default: false,
+        desc: "Skip test files"
+
+      method_option :skip_system_test,
+        type: :boolean,
+        default: false,
+        desc: "Skip system test files"
+
+      method_option :skip_bootsnap,
+        type: :boolean,
+        default: false,
+        desc: "Skip bootsnap gem"
+
+      method_option :dev,
+        type: :boolean,
+        default: false,
+        desc: "Setup the application with Gemfile pointing to your Rails checkout"
+
+      method_option :edge,
+        type: :boolean,
+        default: false,
+        desc: "Setup the application with Gemfile pointing to Rails repository"
+
+      method_option :rc,
+        type: :string,
+        default: nil,
+        desc: "Path to file containing extra configuration options for rails command"
+
+      method_option :no_rc,
+        type: :boolean,
+        default: false,
+        desc: "Skip loading of extra configuration options from .railsrc file"
+
+      method_option :api,
+        type: :boolean,
+        desc: "Preconfigure smaller stack for API only apps"
+
+      method_option :skip_bundle,
+        type: :boolean,
+        aliases: "-B",
+        default: false,
+        desc: "Don't run bundle install"
+
+      method_option :webpack,
+        type: :string,
+        default: nil,
+        desc: "Preconfigure for app-like JavaScript with Webpack (options: #{WEBPACKS.join('/')})"
+
+      desc "new APP_PATH [options]", "generate a gnarly rails app"
       long_desc <<-LONGDESC
         `gnarails new NAME` will create a new rails application called NAME,
         pre-built with the same helpful default configuration you can expect from
@@ -17,10 +165,27 @@ module Gnarails
         You should also be able to pass any other arguments you would expect to
         be able to when generating a new rails app.
       LONGDESC
-      def new(name, rails_options = nil)
-        default_options = "--skip-test-unit --database=postgresql"
+      def new(name)
+        Kernel.system "rails new #{name} #{cli_options(options)}"
+      end
 
-        system "rails new #{name} -m #{Gnarails.template_file} #{default_options} #{rails_options}"
+      no_tasks do
+        def cli_options(options)
+          options_string = "-m #{Gnarails.template_file} --skip-test-unit --database=postgresql"
+          options.each_with_object(options_string) do |(k, v), str|
+            str << cli_option(k, v)
+          end
+        end
+
+        def cli_option(key, value)
+          if value == false
+            ""
+          elsif value == true
+            " --#{key}"
+          else
+            " --#{key}=#{value}"
+          end
+        end
       end
     end
   end

--- a/spec/gnarails/cli/application_spec.rb
+++ b/spec/gnarails/cli/application_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+module Gnarails
+  module Cli
+    RSpec.describe Application do
+      describe "#new" do
+        it "creates a new rails application" do
+          application = Gnarails::Cli::Application.new
+
+          allow(Kernel).to receive(:system)
+
+          application.options = { webpack: "react", skip_yarn: false, skip_git: true }
+          application.new("name")
+
+          default_options = "-m #{Gnarails.template_file} --skip-test-unit --database=postgresql"
+          options = "#{default_options} --webpack=react --skip_git"
+
+          expect(Kernel).to have_received(:system)
+            .with("rails new name #{options}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This explicitly sets all of the different options from creating a new
rails app that a gnarails application will accept. This includes all
options that are available when generating a rails application, while
excluding options that aren't applicable when using this template, such
as the database option or the template option. These are explicitly set
by using gnarails, and as such, are not available for users of this
generator.

Closes #92 