### PR TITLE
Allow pushing to rubygems

### DIFF
--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -8,18 +8,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["The Gnar Company"]
   spec.email         = ["hi@thegnar.co"]
 
-  spec.summary       = "A rails template to provide a fully-loaded Gnar Rails app."
+  spec.summary       = "Easily create a gnarly rails app."
   spec.homepage      = "https://github.com/TheGnarCo/gnarails"
   spec.license       = "MIT"
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
This removes the limitation in the gemspec to prevent the application
from being pushed to the rubygems server, in preparation for a public
release.