### PR TITLE
Depend on chromedriver, lock Rails version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
       - restore_cache:
           keys:
           - gnarails-{{ checksum "gnarails.gemspec" }}
-          # fallback to using the latest cache if no exact match is found
-          - gnarails-
 
       # cmake is required by Rugged, a dependency of Pronto
       - run:

--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "rails"
+  spec.add_dependency "chromedriver-helper"
+  spec.add_dependency "rails", "~> 5.1.5"
   spec.add_dependency "rspec-rails"
   spec.add_dependency "thor"
 


### PR DESCRIPTION
This specifies that this should create a Rails 5.1 version, and also
includes chromedriver-helper, which is used as part of the rspec install
process.