### PR TITLE
Update README template instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ gnarails CLI command, you may clone the project (or reference the template from
 its HTTP location on github):
 
 ```sh
-$ rails new <APP_NAME> -m https://raw.githubusercontent.com/TheGnarCo/gnarails/master/gnarly.rb --skip-test-unit --database=postgresql
+$ git clone https://github.com/TheGnarCo/gnarails.git
+$ cd where/app/will/go
+$ rails new <APP_NAME> -m path/to/gnarly.rb --skip-test-unit --database=postgresql
 ```
 
 A`.railsrc` is provided. If you'd like to symlink it to your home directory, it'll run `rails new` with the options to run with postgres and not including test-unit. This `.railsrc` can be personalized to include the `--template=path/to/gnarly.rb` option depending on where you locally store this repo if you'd like to use this template every time.
@@ -38,7 +40,9 @@ $ gnarails new <APP_NAME> --webpack=react
 ### Using the template
 
 ```sh
-$ rails new <APP_NAME> -m https://raw.githubusercontent.com/TheGnarCo/gnarails/master/gnarly.rb --skip-test-unit --database=postgresql --webpack=react
+$ git clone https://github.com/TheGnarCo/gnarails.git
+$ cd where/app/will/go
+$ rails new <APP_NAME> -m path/to/gnarly.rb --skip-test-unit --database=postgresql --webpack=react
 ```
 
 ## Post-Install


### PR DESCRIPTION
This changes the README instructions for using the template back to
pulling down the project locally and using the template file locally
rather than pulling from the github HTTP location.

The reason for this is that the template relies on particular files
being available at certain paths/locations, and pulling the template
from the HTTP resource does not allow for that.

Closes #104