### PR TITLE
Remove chromedriver-helper dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current release (in development)
 
+* Remove chromedriver-helper dependency [#108](https://github.com/TheGnarCo/gnarails/pull/108)
+
+  [Kevin Murphy](https://github.com/kevin-j-m)
+
 ## 0.9.1 - 2018-03-27
 
 * Lock rails version at 5.1 release (at least 5.1.5) [#106](https://github.com/TheGnarCo/gnarails/pull/106)

--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "chromedriver-helper"
   spec.add_dependency "rails", "~> 5.1.5"
   spec.add_dependency "rspec-rails"
   spec.add_dependency "thor"


### PR DESCRIPTION
This was added in an attempt to allay concerns about a local dependency
not being met. However, I do not believe that this tool should be
explicit on how the user chooses to have chromedriver installed and
managed on their system.