### PR TITLE
Bundle before running rspec generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current release (in development)
 
+* Bundle to gather gems before generating rspec [#110](https://github.com/TheGnarCo/gnarails/pull/110)
+
+  [Kevin Murphy](https://github.com/kevin-j-m)
+
 ## 0.9.2 - 2018-03-27
 
 * Remove chromedriver-helper dependency [#108](https://github.com/TheGnarCo/gnarails/pull/108)

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -109,6 +109,7 @@ def setup_gitignore
 end
 
 def setup_testing
+  run "bundle install"
   setup_rspec
   setup_factory_bot
   setup_system_tests


### PR DESCRIPTION
This explicitly runs bundle before running the rspec generator. The
expectation is that this should resolve an issue where if a system does
not have the gems that are added to the rails app's Gemfile, they will
be installed before running any commands that rely on having them.