### PR TITLE
Use current RUBY_VERSION instead of hardcoding it

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -5,8 +5,6 @@ def source_paths
     [File.expand_path(File.dirname(__FILE__))]
 end
 
-RUBY_VERSION = "2.5.0".freeze
-
 JS_DEPENDENCIES = [
   "babel-preset-es2015".freeze,
   "babel-preset-stage-0".freeze,


### PR DESCRIPTION
Currently gnarails overrides the `RUBY_VERSION` constant to always be
`2.5.0`. This is fine, but is inflexible and forces users of the gem to
be on Ruby 2.5.0 to use the generator.

This change makes gnarails use the default value of `RUBY_VERSION` which
is the currently installed version of Ruby.