### PR TITLE
Replace specific gsub with regular expression

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -123,7 +123,7 @@ def setup_rspec
   remove_file ".rspec"
   copy_file "templates/.rspec", ".rspec"
   gsub_file "spec/rails_helper.rb",
-    "# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }",
+    /# Dir\[Rails\.root\.join.*/,
     "Dir[Rails.root.join(\"spec/support/**/*.rb\")].each { |f| require f }"
 end
 


### PR DESCRIPTION
Currently the tests are failing locally and on CircleCI. The cause seems
to be because the spec support folders aren't being loaded.

This resolves the issue by making the match replacement slightly less
specific to ensure that the correct line is added to the file.