### PR TITLE
Use application's Gemfile, not gnarrails Gemfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,10 @@ jobs:
       # Bundle install dependencies
       - run:
           name: install dependencies
-          command: bundle install --path vendor/bundle
+          command: bundle install
 
       # Store bundle cache
       - save_cache:
-          paths:
-            - vendor/bundle
           key: gnarails-{{ checksum "gnarails.gemspec" }}
 
       # Tests
@@ -65,12 +63,10 @@ jobs:
       # Bundle install dependencies
       - run:
           name: Install Dependencies
-          command: bundle install --path vendor/bundle
+          command: bundle install
 
       # Store bundle cache
       - save_cache:
-          paths:
-            - vendor/bundle
           key: gnarails-build-rails-{{ checksum "gnarails.gemspec" }}
 
       # Generate test app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,6 @@ jobs:
           name: install dependencies
           command: bundle install
 
-      # Store bundle cache
-      - save_cache:
-          key: gnarails-{{ checksum "gnarails.gemspec" }}
-
       # Tests
       - run:
           name: RSpec
@@ -64,10 +60,6 @@ jobs:
       - run:
           name: Install Dependencies
           command: bundle install
-
-      # Store bundle cache
-      - save_cache:
-          key: gnarails-build-rails-{{ checksum "gnarails.gemspec" }}
 
       # Generate test app
       - run:
@@ -107,13 +99,7 @@ jobs:
       # Bundle install dependencies
       - run:
           name: Install Dependencies
-          command: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: gnarails-build-rails-react-{{ checksum "gnarails.gemspec" }}
+          command: bundle install
 
       # Generate test app
       - run:
@@ -168,13 +154,7 @@ jobs:
       # Bundle install dependencies
       - run:
           name: install dependencies
-          command: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: gnarails-test-rails-app-{{ checksum "Gemfile.lock" }}
+          command: bundle install
 
       # Database setup
       - run:

--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "rails", "~> 5.1.5"
-  spec.add_dependency "rspec-rails"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -45,7 +45,30 @@ JS_DEV_DEPENDENCIES = [
 ].freeze
 
 def create_gnarly_rails_app
-  post_bundle
+  # This is a really unfortunate, but necessary line of code that resets the
+  # cached Gemfile location so the generated application's Gemfile is used
+  # instead of the generators Gemfile.
+  ENV["BUNDLE_GEMFILE"] = nil
+
+  add_gems
+
+  run "bundle install"
+
+  after_bundle do
+    setup_database
+    add_ruby_version
+    setup_scss
+    setup_gitignore
+    setup_testing
+    setup_analysis
+    setup_environments
+    setup_readme
+    setup_react if react?
+    remove_dir "test"
+    git :init
+    format_ruby
+    completion_notification
+  end
 end
 
 def add_gems
@@ -301,33 +324,6 @@ end
 
 def react?
   options[:webpack] == "react"
-end
-
-def post_bundle
-  # This is a really unfortunate, but necessary line of code that resets the
-  # cached Gemfile location so the generated application's Gemfile is used
-  # instead of the generators Gemfile.
-  ENV["BUNDLE_GEMFILE"] = nil
-
-  add_gems
-
-  run "bundle install"
-
-  after_bundle do
-    setup_database
-    add_ruby_version
-    setup_scss
-    setup_gitignore
-    setup_testing
-    setup_analysis
-    setup_environments
-    setup_readme
-    setup_react if react?
-    remove_dir "test"
-    git :init
-    format_ruby
-    completion_notification
-  end
 end
 
 def ascii_art

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -50,16 +50,19 @@ def create_gnarly_rails_app
   # instead of the generators Gemfile.
   ENV["BUNDLE_GEMFILE"] = nil
 
+  # Prevent spring cache when generating application
+  ENV["DISABLE_SPRING"] = "true"
+
   add_gems
 
   run "bundle install"
 
   after_bundle do
+    setup_testing
     setup_database
     add_ruby_version
     setup_scss
     setup_gitignore
-    setup_testing
     setup_analysis
     setup_environments
     setup_readme
@@ -88,7 +91,7 @@ def add_gems
     gem 'pronto-scss', require: false
     gem 'pry-rails'
     gem 'rspec-its'
-    gem 'rspec-rails'
+    gem 'rspec-rails', '~> 3.7'
     gem 'scss_lint', require: false
     gem 'selenium-webdriver'
     gem 'shoulda-matchers'

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -45,6 +45,11 @@ JS_DEV_DEPENDENCIES = [
 ].freeze
 
 def create_gnarly_rails_app
+  # This is a really unfortunate, but necessary line of code that resets the
+  # cached Gemfile location so the generated application's Gemfile is used
+  # instead of the generators Gemfile.
+  ENV["BUNDLE_GEMFILE"] = nil
+
   add_gems
   setup_database
   add_ruby_version

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -45,20 +45,6 @@ JS_DEV_DEPENDENCIES = [
 ].freeze
 
 def create_gnarly_rails_app
-  # This is a really unfortunate, but necessary line of code that resets the
-  # cached Gemfile location so the generated application's Gemfile is used
-  # instead of the generators Gemfile.
-  ENV["BUNDLE_GEMFILE"] = nil
-
-  add_gems
-  setup_database
-  add_ruby_version
-  setup_scss
-  setup_gitignore
-  setup_testing
-  setup_analysis
-  setup_environments
-  setup_readme
   post_bundle
 end
 
@@ -114,7 +100,6 @@ def setup_gitignore
 end
 
 def setup_testing
-  run "bundle install"
   setup_rspec
   setup_factory_bot
   setup_system_tests
@@ -319,7 +304,24 @@ def react?
 end
 
 def post_bundle
+  # This is a really unfortunate, but necessary line of code that resets the
+  # cached Gemfile location so the generated application's Gemfile is used
+  # instead of the generators Gemfile.
+  ENV["BUNDLE_GEMFILE"] = nil
+
+  add_gems
+
+  run "bundle install"
+
   after_bundle do
+    setup_database
+    add_ruby_version
+    setup_scss
+    setup_gitignore
+    setup_testing
+    setup_analysis
+    setup_environments
+    setup_readme
     setup_react if react?
     remove_dir "test"
     git :init


### PR DESCRIPTION
Currently when generating an app, Gnarails Gemfile is used which, with
the exception of rspec-rails has all of the dependencies necessary to
run the Rails app which makes this bug harder to find.

When Bundler starts it looks up the directory tree for a `Gemfile` and
finds `gnarails` Gemfile first. This isn't a problem except that it's
cached in the `BUNDLE_GEMFILE` environment variable. This means each
command we run on the generated app is trying to use gnarails
`Gemfile` instead of its own. Because it's an environment variable new shells (like running
commands in a Ruby script via backticks) inherit this value and further
hide the root cause of the strange behavior.

To resolve this issue, once we start running commands on the generated
app we reset the `BUNDLE_GEMFILE` environment variable to clear the
cache and allow Bundler to find the generated applications Gemfile.