### PR TITLE
Use application's Gemfile, not gnarrails Gemfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,6 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - gnarails-{{ checksum "gnarails.gemspec" }}
-
       # cmake is required by Rugged, a dependency of Pronto
       - run:
           name: Install cmake
@@ -25,13 +20,7 @@ jobs:
       # Bundle install dependencies
       - run:
           name: install dependencies
-          command: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: gnarails-{{ checksum "gnarails.gemspec" }}
+          command: bundle install
 
       # Tests
       - run:
@@ -45,33 +34,20 @@ jobs:
 
   build-rails:
     docker:
-      - image: ruby:2.5.0
+      - image: circleci/ruby:2.5.0-stretch-node-browsers
 
     steps:
       - checkout
 
-      # Restore bundle cache
-      - restore_cache:
-          keys:
-          - gnarails-build-rails-{{ checksum "gnarails.gemspec" }}
-          # fallback to using the latest cache if no exact match is found
-          - gnarails-build-rails-
-
       # cmake is required by Rugged, a dependency of Pronto
       - run:
           name: Install cmake
-          command: apt-get -y -qq update && apt-get -y -qq install cmake
+          command: sudo apt-get -y -qq update && sudo apt-get -y -qq install cmake
 
       # Bundle install dependencies
       - run:
           name: Install Dependencies
-          command: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: gnarails-build-rails-{{ checksum "gnarails.gemspec" }}
+          command: bundle install
 
       # Generate test app
       - run:
@@ -91,33 +67,20 @@ jobs:
 
   build-rails-react:
     docker:
-      - image: starefossen/ruby-node:2-8
+      - image: circleci/ruby:2.5.0-stretch-node-browsers
 
     steps:
       - checkout
 
-      # Restore bundle cache
-      - restore_cache:
-          keys:
-          - gnarails-build-rails-react-{{ checksum "gnarails.gemspec" }}
-          # fallback to using the latest cache if no exact match is found
-          - gnarails-build-rails-react-
-
       # cmake is required by Rugged, a dependency of Pronto
       - run:
           name: Install cmake
-          command: apt-get -y -qq update && apt-get -y -qq install cmake
+          command: sudo apt-get -y -qq update && sudo apt-get -y -qq install cmake
 
       # Bundle install dependencies
       - run:
           name: Install Dependencies
-          command: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: gnarails-build-rails-react-{{ checksum "gnarails.gemspec" }}
+          command: bundle install
 
       # Generate test app
       - run:
@@ -157,13 +120,6 @@ jobs:
           name: Copy Test App
           command: cp -r /tmp/rails-test-app/rails-test-app/* ~/project
 
-      # Restore bundle cache
-      - restore_cache:
-          keys:
-          - gnarails-test-rails-app-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - gnarails-test-rails-app-
-
       # cmake is required by Rugged, a dependency of Pronto
       - run:
           name: Install cmake
@@ -172,13 +128,7 @@ jobs:
       # Bundle install dependencies
       - run:
           name: install dependencies
-          command: bundle install --path vendor/bundle
-
-      # Store bundle cache
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: gnarails-test-rails-app-{{ checksum "Gemfile.lock" }}
+          command: bundle install
 
       # Database setup
       - run:

--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "rails", "~> 5.1.5"
-  spec.add_dependency "rspec-rails"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -43,6 +43,11 @@ JS_DEV_DEPENDENCIES = [
 ].freeze
 
 def create_gnarly_rails_app
+  # This is a really unfortunate, but necessary, line of code that resets the
+  # cached Gemfile location so the generated application's Gemfile is used
+  # instead of the generators Gemfile.
+  ENV["BUNDLE_GEMFILE"] = nil
+
   add_gems
   setup_database
   add_ruby_version

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -48,16 +48,28 @@ def create_gnarly_rails_app
   # instead of the generators Gemfile.
   ENV["BUNDLE_GEMFILE"] = nil
 
+  # Prevent spring cache when generating application
+  ENV["DISABLE_SPRING"] = "true"
+
   add_gems
-  setup_database
-  add_ruby_version
-  setup_scss
-  setup_gitignore
-  setup_testing
-  setup_analysis
-  setup_environments
-  setup_readme
-  post_bundle
+
+  run "bundle install"
+
+  after_bundle do
+    setup_testing
+    setup_database
+    add_ruby_version
+    setup_scss
+    setup_gitignore
+    setup_analysis
+    setup_environments
+    setup_readme
+    setup_react if react?
+    remove_dir "test"
+    git :init
+    format_ruby
+    completion_notification
+  end
 end
 
 def add_gems
@@ -77,7 +89,7 @@ def add_gems
     gem 'pronto-scss', require: false
     gem 'pry-rails'
     gem 'rspec-its'
-    gem 'rspec-rails'
+    gem 'rspec-rails', '~> 3.7'
     gem 'scss_lint', require: false
     gem 'selenium-webdriver'
     gem 'shoulda-matchers'
@@ -112,7 +124,6 @@ def setup_gitignore
 end
 
 def setup_testing
-  run "bundle install"
   setup_rspec
   setup_factory_bot
   setup_system_tests
@@ -314,16 +325,6 @@ end
 
 def react?
   options[:webpack] == "react"
-end
-
-def post_bundle
-  after_bundle do
-    setup_react if react?
-    remove_dir "test"
-    git :init
-    format_ruby
-    completion_notification
-  end
 end
 
 def ascii_art


### PR DESCRIPTION
Currently when generating an app, Gnarails Gemfile is used which, with
the exception of rspec-rails has all of the dependencies necessary to
run the Rails app which makes this bug harder to find.

When Bundler starts it looks up the directory tree for a `Gemfile` and
finds `gnarails` Gemfile first. This isn't a problem except that it's
cached in the `BUNDLE_GEMFILE` environment variable. This means each
command we run on the generated app is trying to use gnarails `Gemfile`
instead of its own. Because it's an environment variable new shells
(like running commands in a Ruby script via backticks) inherit this
value and further hide the root cause of the strange behavior.

To resolve this issue, once we start running commands on the generated
app we reset the `BUNDLE_GEMFILE` environment variable to clear the
cache and allow Bundler to find the generated applications Gemfile.
