### PR TITLE
Upgrade Ruby to 2.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   unit_test:
     docker:
-      - image: circleci/ruby:2.5.0-stretch-node-browsers
+      - image: circleci/ruby:2.5.1-stretch-node-browsers
         environment:
           RAILS_ENV: test
     steps:
@@ -34,7 +34,7 @@ jobs:
 
   build-rails:
     docker:
-      - image: circleci/ruby:2.5.0-stretch-node-browsers
+      - image: circleci/ruby:2.5.1-stretch-node-browsers
 
     steps:
       - checkout
@@ -67,7 +67,7 @@ jobs:
 
   build-rails-react:
     docker:
-      - image: circleci/ruby:2.5.0-stretch-node-browsers
+      - image: circleci/ruby:2.5.1-stretch-node-browsers
 
     steps:
       - checkout
@@ -100,7 +100,7 @@ jobs:
 
   test-rails-app:
     docker:
-      - image: circleci/ruby:2.5.0-stretch-node-browsers
+      - image: circleci/ruby:2.5.1-stretch-node-browsers
         environment:
           RAILS_ENV: test
           PG_HOST: localhost


### PR DESCRIPTION
This is necessary for Rails 5.2.1 to run on the CircleCI images which
makes no sense, but I've already spent more of my life investigating it
than I wanted to so I won't go into detail here to spend more of my life
on the issue.

Fixes https://github.com/TheGnarCo/gnarails/issues/111