### PR TITLE
Save Capybara screenshot failures on CI

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -64,3 +64,8 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: coverage
+
+      # Save Capybara Screenshots
+      - store_artifacts:
+          path: tmp/screenshots
+          destination: capybara/screenshots


### PR DESCRIPTION
Rails system tests will save a screenshot for any failure, stored to
tmp/screenshots. This can provide helpful context to understand why a
test failed.

Right now, should a system test fail on CI, we receive a notification of
the failure, along with a message that there is a screenshot; however,
because we do not have access to the file system, we can't actually
review that screenshot.

This modifies the Circle CI configuration so that this directory is
saved as an artifact so any screenshots should be available after the
build run in the Artifacts tab, along with items like the coverage
analysis and the brakeman results.