### PR TITLE
bug(Fix chromedriver install instructions)

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -285,7 +285,8 @@ def post_install_instructions
   puts "\n\nNEXT STEPS"
   puts "=========="
   puts "* Install Google Chrome for acceptance tests"
-  puts "* Install ChromeDriver for default headless acceptance tests: brew install chromedriver"
+  puts "* Ensure you have Homebrew Cask installed: brew tap homebrew/cask"
+  puts "* Install ChromeDriver for default headless acceptance tests: brew cask install chromedriver"
   puts "* Follow the post-install instructions to set up circle to allow gnarbot to comment on PRs."
   puts "  * https://github.com/TheGnarCo/gnarails#post-install"
 end

--- a/templates/README.md
+++ b/templates/README.md
@@ -20,7 +20,8 @@ To run acceptance tests chromedriver is required.
 If using macOS and homebrew, you can install chromedriver with the following
 command:
 ```sh
-$ brew install chromedriver
+$ brew tap homebrew/cask
+$ brew cask install chromedriver
 ```
 
 To run the full test suite:


### PR DESCRIPTION
This commit:

* Updates the post-install instructions to download chromedriver from
Homebrew Cask.

Why?

* chromedriver has moved to Homebrew Cask and cannot be installed with
`brew install` anymore.