### PR TITLE
Point circleci script calls to new location

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -48,12 +48,12 @@ jobs:
           command: bundle exec bundle-audit update && bundle exec bundle-audit check
       - run:
           name: Brakeman
-          command: ./script/brakeman
+          command: ./bin/brakeman
 
       # Pronto
       - run:
           name: Pronto
-          command: ./script/ci_pronto
+          command: ./bin/ci_pronto
 
       # Save Brakeman
       - store_artifacts:


### PR DESCRIPTION
In https://github.com/TheGnarCo/gnarails/pull/121 the script directory
was renamed to `bin` but the circleci config was never updated.

This updates the circleci script to point to the new, correct location.