### PR TITLE
Set main element

### DIFF
--- a/test-app/app/views/layouts/application.html.erb
+++ b/test-app/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" role="main">
+<html lang="en">
   <head>
     <title>RailsTestApp</title>
     <%= csrf_meta_tags %>
@@ -9,6 +9,8 @@
   </head>
 
   <body>
-    <%= yield %>
+    <main>
+      <%= yield %>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
This provides a main element in the application layout, for
accessibility benefits. This was caught by axe-matchers, which proposed
the use of the `role="main"` ARIA landmark. However, the use of the
`main` element is preferred, I believe unless there are legacy browser
issues.