### PR TITLE
Add simple Procfile

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -275,6 +275,7 @@ def setup_environments
   setup_dotenv
   setup_ci
   setup_docker
+  setup_procfile
 end
 
 def setup_dotenv
@@ -299,6 +300,10 @@ def setup_docker
   else
     setup_docker_standard
   end
+end
+
+def setup_procfile
+  copy_file "templates/Procfile", "Procfile"
 end
 
 def setup_docker_standard

--- a/templates/Procfile
+++ b/templates/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma


### PR DESCRIPTION
This adds a simple Procfile which will be used by Heroku and can also be
used by tools like `heroku`s `local` command, forego, foreman, etc.

Resolves https://github.com/TheGnarCo/gnarails/issues/23