### PR TITLE
Remove Usage of --rdoc and --ri

### DIFF
--- a/templates/bin/brakeman
+++ b/templates/bin/brakeman
@@ -2,7 +2,7 @@
 #
 # Script for running Brakeman tests
 # Brakeman is a security scanner https://github.com/presidentbeef/brakeman.
-gem install --no-rdoc --no-ri brakeman
+gem install brakeman --no-document
 
 brakeman --exit-on-warn --separate-models -o tmp/brakeman.html -o tmp/brakeman.text .
 brakeman_exit_code=$?


### PR DESCRIPTION
Rubygems 3.0.0 removed the --rdoc and --ri options from install and
update, which were deprecated previously. This was removed in the
following pull request: https://github.com/rubygems/rubygems/pull/2354.

This removes the use of these options in favor of the new `--no-document`
option. The documentation states that this option will,
"disable documentation generation".