### PR TITLE
Support bundler 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,16 +44,6 @@ jobs:
           name: Install cmake
           command: sudo apt-get -y -qq update && sudo apt-get -y -qq install cmake
 
-      # Remove bundler 2
-      - run:
-          name: Uninstall bundler
-          command: sudo gem uninstall bundler
-
-      # Install specific version of bundler
-      - run:
-          name: Install bundler 1.17.2
-          command: sudo gem install bundler -v 1.17.2
-
       # Install rake after installing specific version of bundler
       - run:
           name: Install rake
@@ -109,7 +99,7 @@ jobs:
 
       # Bundle install dependencies
       - run:
-          name: install dependencies
+          name: Install dependencies
           command: bundle install
 
       # Database setup

--- a/gnarails.gemspec
+++ b/gnarails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", "~> 5.2.1"
   spec.add_dependency "thor"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "gnar-style"
   spec.add_development_dependency "pronto"
   spec.add_development_dependency "pronto-rubocop"


### PR DESCRIPTION
This commit:

* Runs the command `gem install bundler` to update bundler from the
version 1.x that ships with the ruby image to bundler version 2.x.

closes #133 