### PR TITLE
Raise error on missing translations in dev and test.

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -84,6 +84,7 @@ def setup_testing
   setup_shoulda
   setup_bullet
   limit_test_logging
+  remove_chromedriver_helper
 end
 
 def setup_rspec
@@ -186,6 +187,10 @@ def limit_test_logging
   end
     TEST_LOGGING
   end
+end
+
+def remove_chromedriver_helper
+  gsub_file "Gemfile", /(\s+#.*\s+)gem 'chromedriver-helper'/, ""
 end
 
 def setup_analysis

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -277,18 +277,16 @@ def setup_readme
 end
 
 def setup_i18n
-  missing_translation_config = <<-CONFIG
-
-  # Raise error when missing i18n translations
-  config.action_view.raise_on_missing_translations = true
-  CONFIG
-
-  insert_into_file "config/environments/test.rb", after: "Rails.application.configure do" do
-    missing_translation_config
-  end
-  insert_into_file "config/environments/development.rb", after: "Rails.application.configure do" do
-    missing_translation_config
-  end
+  gsub_file(
+    "config/environments/test.rb",
+    "# config.action_view.raise_on_missing_translations = true",
+    "config.action_view.raise_on_missing_translations = true",
+  )
+  gsub_file(
+    "config/environments/development.rb",
+    "# config.action_view.raise_on_missing_translations = true",
+    "config.action_view.raise_on_missing_translations = true",
+  )
 end
 
 def ascii_art

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -238,7 +238,7 @@ def setup_environments
   setup_ci
   setup_docker
   setup_procfile
-  setup_i18n
+  configure_i18n
 end
 
 def setup_dotenv
@@ -276,7 +276,7 @@ def setup_readme
   gsub_file "README.md", "__application_name__", app_name
 end
 
-def setup_i18n
+def configure_i18n
   gsub_file(
     "config/environments/test.rb",
     "# config.action_view.raise_on_missing_translations = true",

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -233,6 +233,7 @@ def setup_environments
   setup_ci
   setup_docker
   setup_procfile
+  setup_i18n
 end
 
 def setup_dotenv
@@ -268,6 +269,21 @@ def setup_readme
   remove_file "README.md"
   copy_file "templates/README.md", "README.md"
   gsub_file "README.md", "__application_name__", app_name
+end
+
+def setup_i18n
+  missing_translation_config = <<-CONFIG
+
+  # Raise error when missing i18n translations
+  config.action_view.raise_on_missing_translations = true
+  CONFIG
+
+  insert_into_file "config/environments/test.rb", after: "Rails.application.configure do" do
+    missing_translation_config
+  end
+  insert_into_file "config/environments/development.rb", after: "Rails.application.configure do" do
+    missing_translation_config
+  end
 end
 
 def ascii_art


### PR DESCRIPTION
Resolves #142 

This PR adds `config.action_view.raise_on_missing_translations = true` to the default config files for `dev` and `test`. This will throw errors for missing translations instead of using fallbacks by default.

This PR also removes the `chromedriver-helper` gem from the generated Gemfile, as this causes errors when running on CI. Regardless, that gem is deprecated, _and_ we instruct the user to install chromedriver in the post-install message anyways.