### PR TITLE
Handle change of CircleCI images after ruby 2.7.0

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -245,8 +245,16 @@ end
 
 def setup_ci
   copy_file "templates/.circleci/config.yml", ".circleci/config.yml"
-  gsub_file ".circleci/config.yml", "__ruby_version__", RUBY_VERSION
+  gsub_file ".circleci/config.yml", "__ruby_image_suffix__", ruby_image_suffix
   gsub_file ".circleci/config.yml", "__application_name__", app_name
+end
+
+def ruby_image_suffix
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7.0")
+    "#{RUBY_VERSION}-stretch-node-browsers"
+  else
+    "#{RUBY_VERSION}-buster-node-browsers"
+  end
 end
 
 def setup_docker

--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: circleci/ruby:__ruby_version__-stretch-node-browsers
+      - image: circleci/ruby:__ruby_image_suffix__
         environment:
           RAILS_ENV: test
       - image: circleci/postgres:9.6.5


### PR DESCRIPTION
**This Commit**
Updates the template's `.circleci/config.yml` to conditionally determine
the CircleCI image name for ruby.

**Why?**
CircleCI switched its images from `stretch-...` to `buster-...` with the
[new release of Debian](https://discuss.circleci.com/t/docker-convenience-images-updates-july-2019/31239). Because of this, if the user generated a new rails app with ruby 2.7.x
installed, they would attemp to reference the image `2.7.x-stretch-node-browsers`
which isn't available. Instead, it should be [`2.7.x-buster-node-browsers`](https://hub.docker.com/r/circleci/ruby/tags?page=1&name=2.7).

**Question**
Do we even need the debian name? I see images like [`2.7-node-browsers`](https://hub.docker.com/layers/circleci/ruby/2.7-node-browsers/images/sha256-de934cb93ef55dd35084935ffccb8e5f2557c3a02280a87d4dbb058a25a96eee?context=explore) do we know if those would work so we don't have to update anything when CircleCI moves to new Debian releases? Or is the stability of the underlying OS pretty important in most cases?

**Note**
I don't have a CircleCI anything setup so I couldn't test this super confidently. All I did was:
```
rbenv local 2.6.5/2.7.1 && rails new --template=path test_whatever
```
and verified the ruby image name. I could've typo'ed the image name and wouldn't know it until it hit CircleCI and failed. I feel like there could be a spec for this but I wasn't positive where that should happen.