### PR TITLE
Update postgres version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           PG_HOST: localhost
           PG_USER: ubuntu
           DATABASE_URL: "postgres://ubuntu@localhost:5432/rails-test-app-test"
-      - image: circleci/postgres:9.6.5
+      - image: circleci/postgres:13.0
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: rails-test-app-test

--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       - image: circleci/ruby:__ruby_version__-stretch-node-browsers
         environment:
           RAILS_ENV: test
-      - image: circleci/postgres:9.6.5
+      - image: circleci/postgres:13.0
+          environment:
+            POSTGRES_HOST_AUTH_METHOD:trust
     steps:
       - checkout
 


### PR DESCRIPTION
**This Commit**
Updates the postgres version in the CircleCI config to be 13.0

**Why?**
Because new users with new DBs will probably not be running 9.6.5 so
having CI use it is unlikely to match their environment. They may use
new features that break in CI because of the old version. Also, who
knows, maybe the new version is faster and everyone's CI will be better.

**Note**
There are two methods for handling auth for these postgres images
described [here](https://discuss.circleci.com/t/postgresql-image-password-not-specified-issue/34555). I chose to just disable the auth as it matches what we had before but we
could also set up some username/password in the database.yml and match
that (I imagine).