### PR TITLE
Print completion steps with newer Thor version

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -308,7 +308,7 @@ def post_install_instructions
 end
 
 def format_ruby
-  run "bundle exec rubocop --auto-correct"
+  run "bundle exec rubocop --auto-correct", abort_on_failure: false
 end
 
 def completion_notification


### PR DESCRIPTION
**This Commit**
Prints the ascii-art and completion steps post-installation with newer
versions of thor.

**Why?**
thor was [updated](https://github.com/erikhuda/thor/commit/afdcf1cd5f969fcc7502a373a53155b5416906e7) so that, when an action fails, it will check
`self.class.exit_on_failure?`. This is [`true`](https://github.com/erikhuda/thor/blob/master/lib/thor/runner.rb)
for `Thor::Runner` so now, when `rubocop` runs at the end of the
installation process (and invariably fails), the process is quit instead
of printing out the final steps.

By adding `abort_on_failure: false` to the config for `run` for only the
`rubocop` command we ensure that other actions fail as normal (as I assume
they should because I assume the `Thor::Runner` default is intentional)
but the `rubocop` command will not abort (since it'll always fail).

Alternatively, I could define `exit_on_failure?` to be `false` for our
entire runner to make all the actions "backwards compatible" but I'm not
sure if we want that.

Also, I'm not sure if it's worth just fixing all the `rubocop` issues so
the command doesn't fail. Let me know what we'd prefer!