### PR TITLE
[skip ci] Passthrough args to rails new directly

### DIFF
--- a/lib/gnarails/cli/application.rb
+++ b/lib/gnarails/cli/application.rb
@@ -5,153 +5,14 @@ module Gnarails
     class Application < Thor
       include Thor::Actions
 
+      attr_reader :args
+
+      def initialize(args)
+        @args = args
+        super(args)
+      end
+
       add_runtime_options!
-
-      WEBPACKS = %w[react vue angular elm stimulus].freeze
-
-      method_option :ruby,
-        type: :string,
-        aliases: "-r",
-        default: Thor::Util.ruby_command,
-        desc: "Path to the Ruby binary of your choice", banner: "PATH"
-
-      method_option :skip_namespace,
-        type: :boolean,
-        default: false,
-        desc: "Skip namespace (affects only isolated applications)"
-
-      method_option :skip_yarn,
-        type: :boolean,
-        default: false,
-        desc: "Don't use Yarn for managing JavaScript dependencies"
-
-      method_option :skip_gemfile,
-        type: :boolean,
-        default: false,
-        desc: "Don't create a Gemfile"
-
-      method_option :skip_git,
-        type: :boolean,
-        aliases: "-G",
-        default: false,
-        desc: "Skip .gitignore file"
-
-      method_option :skip_keeps,
-        type: :boolean,
-        default: false,
-        desc: "Skip source control .keep files"
-
-      method_option :skip_action_mailer,
-        type: :boolean,
-        aliases: "-M",
-        default: false,
-        desc: "Skip Action Mailer files"
-
-      method_option :skip_active_record,
-        type: :boolean,
-        aliases: "-O",
-        default: false,
-        desc: "Skip Active Record files"
-
-      method_option :skip_active_storage,
-        type: :boolean,
-        default: false,
-        desc: "Skip Active Storage files"
-
-      method_option :skip_puma,
-        type: :boolean,
-        aliases: "-P",
-        default: false,
-        desc: "Skip Puma related files"
-
-      method_option :skip_action_cable,
-        type: :boolean,
-        aliases: "-C",
-        default: false,
-        desc: "Skip Action Cable files"
-
-      method_option :skip_sprockets,
-        type: :boolean,
-        aliases: "-S",
-        default: false,
-        desc: "Skip Sprockets files"
-
-      method_option :skip_spring,
-        type: :boolean,
-        default: false,
-        desc: "Don't install Spring application preloader"
-
-      method_option :skip_listen,
-        type: :boolean,
-        default: false,
-        desc: "Don't generate configuration that depends on the listen gem"
-
-      method_option :skip_coffee,
-        type: :boolean,
-        default: false,
-        desc: "Don't use CoffeeScript"
-
-      method_option :skip_javascript,
-        type: :boolean,
-        aliases: "-J",
-        default: false,
-        desc: "Skip JavaScript files"
-
-      method_option :skip_turbolinks,
-        type: :boolean,
-        default: false,
-        desc: "Skip turbolinks gem"
-
-      method_option :skip_test,
-        type: :boolean,
-        aliases: "-T",
-        default: false,
-        desc: "Skip test files"
-
-      method_option :skip_system_test,
-        type: :boolean,
-        default: false,
-        desc: "Skip system test files"
-
-      method_option :skip_bootsnap,
-        type: :boolean,
-        default: false,
-        desc: "Skip bootsnap gem"
-
-      method_option :dev,
-        type: :boolean,
-        default: false,
-        desc: "Setup the application with Gemfile pointing to your Rails checkout"
-
-      method_option :edge,
-        type: :boolean,
-        default: false,
-        desc: "Setup the application with Gemfile pointing to Rails repository"
-
-      method_option :rc,
-        type: :string,
-        default: nil,
-        desc: "Path to file containing extra configuration options for rails command"
-
-      method_option :no_rc,
-        type: :boolean,
-        default: false,
-        desc: "Skip loading of extra configuration options from .railsrc file"
-
-      method_option :api,
-        type: :boolean,
-        desc: "Preconfigure smaller stack for API only apps"
-
-      method_option :skip_bundle,
-        type: :boolean,
-        aliases: "-B",
-        default: false,
-        desc: "Don't run bundle install"
-
-      method_option :webpack,
-        type: :string,
-        default: nil,
-        desc: "Preconfigure for app-like JavaScript with Webpack (options: #{WEBPACKS.join('/')})"
 
       desc "new APP_PATH [options]", "generate a gnarly rails app"
       long_desc <<-LONGDESC
@@ -165,26 +26,13 @@ module Gnarails
         You should also be able to pass any other arguments you would expect to
         be able to when generating a new rails app.
       LONGDESC
-      def new(name)
-        Kernel.system "rails new #{name} #{cli_options(options)}"
+      def new
+        Kernel.system "rails new #{cli_options}"
       end
 
       no_tasks do
-        def cli_options(options)
-          options_string = "-m #{Gnarails.template_file} --skip-test-unit --database=postgresql"
-          options.each_with_object(options_string) do |(k, v), str|
-            str << cli_option(k, v)
-          end
-        end
-
-        def cli_option(key, value)
-          if value == false
-            ""
-          elsif value == true
-            " --#{key}"
-          else
-            " --#{key}=#{value}"
-          end
+        def cli_options
+          "-m #{Gnarails.template_file} --skip-test-unit --database=postgresql #{args.join(" ")}"
         end
       end
     end


### PR DESCRIPTION
**This Commit**
Does a super-hack job of sort of laying out a method for passing through
all command line args to `rails new`.

**Why?**
1. `gnarails` doesn't accept all the options `rails new` does (I think
the one I ran into was `webpack` or `webpacker` or something, it was
forever ago).
2. `gnarails` probably doesn't want to reinvent `rails new` arguments
for the rest of time

**Note**
This is obviously a super ugly hack. This is basically ejecting from
`thor`. Which is maybe fine since we're basically just sliding a couple
of args into the grand scheme of things. Although, I imagine, the
current setup:
1. doesn't work (I don't know how to test it locally)
2. doesn't allow the user to unset things (I don't know what `rails new`
does with `--database=postgresql --database=something_else` but maybe it
does the right thing)

This is a draft initially because it's ridiculous and clearly wrong but I'm interested in what we can do to achieve more synergy with `rails new`