### PR TITLE
Change instances of "master" to reference "main" 

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,8 +1,7 @@
-* Checkout master: `git checkout master`.
-* Get latest: `git pull --rebase origin master`
-* Bump version number in `lib/gnarails/version.rb`.
-* Update the [CHANGELOG](CHANGELOG.md), moving the current release work to under the version number.
-* Create a commit, including the version number in the commit message: `git add
-  --all && git commit -m "Version x.y.z"`.
-* Push the release to RubyGems: `rake release`.
-* Check the RubyGems [twitter account](https://twitter.com/rubygems) to publicize the release.
+- Checkout master: `git checkout main`.
+- Get latest: `git pull --rebase origin main`
+- Bump version number in `lib/gnarails/version.rb`.
+- Update the [CHANGELOG](CHANGELOG.md), moving the current release work to under the version number.
+- Create a commit, including the version number in the commit message: `git add --all && git commit -m "Version x.y.z"`.
+- Push the release to RubyGems: `rake release`.
+- Check the RubyGems [twitter account](https://twitter.com/rubygems) to publicize the release.

--- a/bin/ci_pronto
+++ b/bin/ci_pronto
@@ -3,4 +3,4 @@
 # Script for running pronto on CI
 export PRONTO_PULL_REQUEST_ID=${CI_PULL_REQUEST##*/}
 
-bundle exec pronto run -f text github_pr_review github_status -c origin/master
+bundle exec pronto run -f text github_pr_review github_status -c origin/main

--- a/templates/bin/ci_pronto
+++ b/templates/bin/ci_pronto
@@ -3,4 +3,4 @@
 # Script for running pronto on CI
 export PRONTO_PULL_REQUEST_ID=${CI_PULL_REQUEST##*/}
 
-bundle exec pronto run -f text github_pr_review github_status -c origin/master
+bundle exec pronto run -f text github_pr_review github_status -c origin/main


### PR DESCRIPTION
This PR updates `templates/ci_pronto`, `bin/ci_pronto`, and `RELEASE_PROCESS.md` with modern branch naming conventions. 

Note: a casual glance around this app shows a number of cases where we can change `master` to `main`. Going to expand the scope of this PR in a moment, setting to draft until then.