### PR TITLE
No longer manually add `capybara` or `selenium` gems

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -38,7 +38,6 @@ def add_gems
     gem 'axe-matchers'
     gem 'bullet'
     gem 'bundler-audit'
-    gem 'capybara'
     gem 'dotenv-rails'
     gem 'factory_bot_rails'
     gem 'gnar-style', require: false
@@ -54,7 +53,6 @@ def add_gems
     gem 'rspec-its'
     gem 'rspec-rails', '~> 3.7'
     gem 'scss_lint', require: false
-    gem 'selenium-webdriver'
     gem 'shoulda-matchers'
     gem 'simplecov', require: false
   end


### PR DESCRIPTION
This PR removes the manual inclusion of `capybara` and `selenium-webdriver` in the gem packages, as both are now included in a fresh `rails new` Gemfile. 

Leaving in `capybara` will cause the `gnarails new` command to stop on an error, and leaving in `selenium` will introduce a warning on `bundle install`. 