### PR TITLE
Fix `generate_test_app` script to no longer fail on CI 

### DIFF
--- a/bin/generate-test-app.sh
+++ b/bin/generate-test-app.sh
@@ -3,7 +3,6 @@ bundle exec exe/gnarails new rails-test-app
 
 mkdir rails-test-app/app/views/job_postings
 mkdir rails-test-app/db/migrate
-mkdir rails-test-app/spec
 mkdir rails-test-app/spec/factories
 mkdir rails-test-app/spec/models
 mkdir rails-test-app/spec/system

--- a/bin/generate-test-app.sh
+++ b/bin/generate-test-app.sh
@@ -3,6 +3,7 @@ bundle exec exe/gnarails new rails-test-app
 
 mkdir rails-test-app/app/views/job_postings
 mkdir rails-test-app/db/migrate
+mkdir rails-test-app/spec
 mkdir rails-test-app/spec/factories
 mkdir rails-test-app/spec/models
 mkdir rails-test-app/spec/system

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -16,7 +16,7 @@ def create_gnarly_rails_app
 
   add_gems
 
-  run "bundle install"
+  run "bin/bundle install"
 
   after_bundle do
     setup_testing

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -16,7 +16,7 @@ def create_gnarly_rails_app
 
   add_gems
 
-  run "bundle install --gemfile='./Gemfile'"
+  run "bundle install"
 
   after_bundle do
     setup_testing

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -16,7 +16,7 @@ def create_gnarly_rails_app
 
   add_gems
 
-  run "bin/bundle install"
+  run "bundle install"
 
   after_bundle do
     setup_testing

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -16,7 +16,7 @@ def create_gnarly_rails_app
 
   add_gems
 
-  run "bundle install"
+  run "bundle install --gemfile='./Gemfile'"
 
   after_bundle do
     setup_testing

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -41,7 +41,7 @@ def add_gems
     gem 'capybara'
     gem 'dotenv-rails'
     gem 'factory_bot_rails'
-    gem 'gnar-style', require: false
+    gem 'gnar-style', '0.12.0', require: false
     gem 'launchy'
     gem 'lol_dba'
     gem 'okcomputer'


### PR DESCRIPTION
This PR makes two small changes to enable the `bin/generate_test_app` to run successfully: 

 - It changes `gnarly.rb` to call `bin/bundle` as opposed to `bundle`. this allows us to properly source the `Gemfile`, removing the 'no gem found in sources' ci error we see now 
 - Adds a line to manually add the `spec` directory before making subdirectories. 
 
 Note: I suspect this will continue to fail CI until the dependency issues in `gnar-style` are resolved (https://github.com/TheGnarCo/gnar-style/pull/53)