### PR TITLE
Remove extraneous entries from Gemfile

### DIFF
--- a/gnarly.rb
+++ b/gnarly.rb
@@ -38,7 +38,6 @@ def add_gems
     gem 'axe-matchers'
     gem 'bullet'
     gem 'bundler-audit'
-    gem 'capybara'
     gem 'dotenv-rails'
     gem 'factory_bot_rails'
     gem 'gnar-style', require: false
@@ -54,7 +53,6 @@ def add_gems
     gem 'rspec-its'
     gem 'rspec-rails', '~> 3.7'
     gem 'scss_lint', require: false
-    gem 'selenium-webdriver'
     gem 'shoulda-matchers'
     gem 'simplecov', require: false
   end

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -16,7 +16,7 @@ def create_gnarly_rails_app
 
   add_gems
 
-  run "bundle install"
+  run_bundle
 
   after_bundle do
     setup_testing

--- a/lib/gnarails/cli/application.rb
+++ b/lib/gnarails/cli/application.rb
@@ -166,10 +166,14 @@ module Gnarails
         be able to when generating a new rails app.
       LONGDESC
       def new(name)
-        Kernel.system "rails new #{name} #{cli_options(options)}"
+        Kernel.system command(name, options)
       end
 
       no_tasks do
+        def command(name, options)
+          "rails new #{name} #{cli_options(options)}"
+        end
+
         def cli_options(options)
           options_string = "-m #{Gnarails.template_file} --skip-test-unit --database=postgresql"
           options.each_with_object(options_string) do |(k, v), str|


### PR DESCRIPTION
When generating a new Rails app, I was confronted with an error that capybara
(and later selenum-webdriver) could not be specified twice with different
version requirements in a Gemfile. The one gnarails was adding had no
specification and the one Rails specified a version. So, since they're being
added as part of `rails new`, we don't need them here.