### PR TITLE
upgrade axe dependencies (Take 2)

### DIFF
--- a/bin/generate-test-app.sh
+++ b/bin/generate-test-app.sh
@@ -20,3 +20,4 @@ cp test-app/spec/factories/job_postings.rb rails-test-app/spec/factories/job_pos
 cp test-app/spec/models/job_posting_spec.rb rails-test-app/spec/models/job_posting_spec.rb
 cp test-app/spec/system/viewing_all_job_postings_spec.rb rails-test-app/spec/system/viewing_all_job_postings_spec.rb
 cp test-app/spec/requests/status_spec.rb rails-test-app/spec/requests/status_spec.rb
+cp test-app/config/brakeman.ignore rails-test-app/config/brakeman.ignore

--- a/gnarly.rb
+++ b/gnarly.rb
@@ -2,7 +2,7 @@
 # to look up files
 def source_paths
   Array(super) +
-    [File.expand_path(File.dirname(__FILE__))]
+    [__dir__]
 end
 
 def create_gnarly_rails_app
@@ -35,26 +35,27 @@ end
 
 def add_gems
   gem_group :development, :test do
-    gem 'axe-matchers'
-    gem 'bullet'
-    gem 'bundler-audit'
-    gem 'dotenv-rails'
-    gem 'factory_bot_rails'
-    gem 'gnar-style', require: false
-    gem 'launchy'
-    gem 'lol_dba'
-    gem 'okcomputer'
-    gem 'pronto'
-    gem 'pronto-brakeman', require: false
-    gem 'pronto-rubocop', require: false
-    gem 'pronto-scss', require: false
-    gem 'pry-byebug'
-    gem 'pry-rails'
-    gem 'rspec-its'
-    gem 'rspec-rails', '~> 3.7'
-    gem 'scss_lint', require: false
-    gem 'shoulda-matchers'
-    gem 'simplecov', require: false
+    gem "axe-core-capybara"
+    gem "axe-core-rspec"
+    gem "bullet"
+    gem "bundler-audit"
+    gem "dotenv-rails"
+    gem "factory_bot_rails"
+    gem "gnar-style", require: false
+    gem "launchy"
+    gem "lol_dba"
+    gem "okcomputer"
+    gem "pronto"
+    gem "pronto-brakeman", require: false
+    gem "pronto-rubocop", require: false
+    gem "pronto-scss", require: false
+    gem "pry-byebug"
+    gem "pry-rails"
+    gem "rspec-its"
+    gem "rspec-rails", "~> 3.7"
+    gem "scss_lint", require: false
+    gem "shoulda-matchers"
+    gem "simplecov", require: false
   end
 end
 
@@ -113,7 +114,8 @@ end
 def system_tests_rails_helper_text
   <<~SYSTEM_TESTS
     require "capybara/rails"
-    require "axe/rspec"
+    require "axe-rspec"
+    require "axe-capybara"
     require "selenium/webdriver"
   SYSTEM_TESTS
 end

--- a/lib/gnarails/cli/application.rb
+++ b/lib/gnarails/cli/application.rb
@@ -182,9 +182,10 @@ module Gnarails
         end
 
         def cli_option(key, value)
-          if value == false
+          case value
+          when false
             ""
-          elsif value == true
+          when true
             " --#{key}"
           else
             " --#{key}=#{value}"

--- a/lib/gnarails/version.rb
+++ b/lib/gnarails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gnarails
   VERSION = "3.0.0"
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "English"
 
 RSpec.describe "Sample App Integration Testing" do
   context "generating a sample application", unless: ENV["CI"] do
@@ -12,9 +13,9 @@ RSpec.describe "Sample App Integration Testing" do
 
     it "runs test-app suite" do
       Bundler.with_clean_env do
-        Dir.chdir('rails-test-app') do
+        Dir.chdir("rails-test-app") do
           `bundle exec rspec`
-          test_app_result=$?.success?
+          test_app_result = $CHILD_STATUS.success?
 
           expect(test_app_result).to be true
         end

--- a/test-app/config/brakeman.ignore
+++ b/test-app/config/brakeman.ignore
@@ -1,0 +1,22 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.6.5 ends on 2022-03-31",
+      "file": "Gemfile.lock",
+      "line": 233,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": "Ruby end-of-life March 31 2022"
+    }
+  ],
+  "updated": "2022-02-11 12:48:16 -0500",
+  "brakeman_version": "5.2.1"
+}

--- a/test-app/spec/system/viewing_all_job_postings_spec.rb
+++ b/test-app/spec/system/viewing_all_job_postings_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Viewing all job postings", type: :system do
     create_list :job_posting, 1
     visit job_postings_path
 
-    expect(page).to be_accessible
+    expect(page).to be_axe_clean
   end
 
   scenario "N+1 query proteection" do
@@ -25,10 +25,6 @@ RSpec.feature "Viewing all job postings", type: :system do
     posting = create :job_posting
     visit job_postings_path
 
-    expect(has_job_posting?(posting)).to be true
-  end
-
-  def has_job_posting?(posting)
     within(".job-posting-#{posting.id}") do
       expect(page).to have_css("td.posting-title", text: posting.title)
     end


### PR DESCRIPTION
# Summary:

This is a second draft of this PR which I just closed: https://github.com/TheGnarCo/gnarails/pull/163.

I removed the commits which officially bumped the gem to the next version.  Everything else is the same.